### PR TITLE
Support configuration of the underlying WebSocketServletFactory

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject inin-purecloud/ring-jetty-ws "1.0.1"
+(defproject inin-purecloud/ring-jetty-ws "1.1.0-SNAPSHOT"
   :description ""
   :url "https://github.com/MyPureCloud/ring-jetty-ws"
   :license {:name "MIT License"


### PR DESCRIPTION
Lots of formatting here, but this allows the consuming application to configure how websockets are created a bit more. In particular, we're using it to register a connection statistics tracker.